### PR TITLE
hugepage: add support to provision hugepages

### DIFF
--- a/doc/provision/hugepages.yaml
+++ b/doc/provision/hugepages.yaml
@@ -1,0 +1,7 @@
+kind: HugePageProvision
+metadata:
+  name: balanced-runtime
+spec:
+  pages:
+  - size: "2M"
+    count: 512

--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/pkg/hugepages/provision/api/v0/types.go
+++ b/pkg/hugepages/provision/api/v0/types.go
@@ -1,0 +1,67 @@
+package v0
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// HugePageSize defines size of huge pages
+// The allowed values for this depend on CPU architecture
+// For x86/amd64, the valid values are 2M and 1G.
+// For aarch64, the valid huge page sizes depend on the kernel page size:
+// - With a 4k kernel page size: 64k, 2M, 32M, 1G
+// - With a 64k kernel page size: 2M, 512M, 16G
+//
+// Reference: https://docs.kernel.org/mm/vmemmap_dedup.html
+type HugePageSize string
+
+// HugePageProvisionSpec defines a set of huge pages that we want to allocate
+type HugePageProvisionSpec struct {
+	// DefaultHugePagesSize defines huge pages default size under kernel boot parameters.
+	DefaultHugePagesSize *HugePageSize `json:"defaultHugepagesSize,omitempty"`
+	// Pages defines huge pages that we want to allocate at boot time.
+	Pages []HugePage `json:"pages,omitempty"`
+}
+
+// HugePageProvisionStatus defines the observed state of Hugepages.
+type HugePageProvisionStatus struct {
+	// Conditions represents the latest available observations of current state.
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// HugePage defines the number of allocated huge pages of the specific size.
+type HugePage struct {
+	// Size defines huge page size, maps to the 'hugepagesz' kernel boot parameter.
+	Size HugePageSize `json:"size,omitempty"`
+	// Count defines amount of huge pages, maps to the 'hugepages' kernel boot parameter.
+	Count int32 `json:"count,omitempty"`
+	// Node defines the NUMA node where hugepages will be allocated,
+	// if not specified, pages will be allocated equally between NUMA nodes
+	// +optional
+	Node *int32 `json:"node,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=performanceprofiles,scope=Cluster
+// +kubebuilder:storageversion
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// HugePageProvision is the Schema for the hugepageprovision API
+type HugePageProvision struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   HugePageProvisionSpec   `json:"spec,omitempty"`
+	Status HugePageProvisionStatus `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// HugePageProvisionList contains a list of HugePage
+type HugePageProvisionList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []HugePageProvision `json:"items"`
+}

--- a/pkg/hugepages/provision/api/v0/validation.go
+++ b/pkg/hugepages/provision/api/v0/validation.go
@@ -1,0 +1,17 @@
+package v0
+
+import "errors"
+
+// ValidateHugePageSize returns the internal (sysfs) hugepage size to use
+// and nil error if is a supported size; otherwise returns empty string
+// and an error detailing the reason
+func ValidateHugePageSize(hps HugePageSize) (string, error) {
+	hpSize := string(hps) // shortcut
+	if hpSize == "1G" || hpSize == "1Gi" || hpSize == "1g" {
+		return "1048576kB", nil
+	}
+	if hpSize == "2M" || hpSize == "2Mi" || hpSize == "2m" {
+		return "2048kB", nil
+	}
+	return "", errors.New("unsupported size")
+}

--- a/pkg/hugepages/provision/provision.go
+++ b/pkg/hugepages/provision/provision.go
@@ -1,0 +1,104 @@
+package provision
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/go-logr/logr"
+	ghwopt "github.com/jaypipes/ghw/pkg/option"
+	ghwtopology "github.com/jaypipes/ghw/pkg/topology"
+
+	"sigs.k8s.io/yaml"
+
+	apiv0 "github.com/ffromani/dra-driver-memory/pkg/hugepages/provision/api/v0"
+)
+
+func ReadConfiguration(source string) (apiv0.HugePageProvision, error) {
+	if source == "-" {
+		return readConfigurationFrom(os.Stdin)
+	}
+	src, err := os.Open(source)
+	if err != nil {
+		return apiv0.HugePageProvision{}, err
+	}
+	defer src.Close()
+	return readConfigurationFrom(src)
+}
+
+func RuntimeHugepages(logger logr.Logger, hpp apiv0.HugePageProvision, sysRoot string) error {
+	logger.V(2).Info("start provisioning hugepages", "groups", len(hpp.Spec.Pages))
+	defer logger.V(2).Info("done provisioning hugepages", "groups", len(hpp.Spec.Pages))
+
+	sysinfo, err := ghwtopology.New(ghwopt.WithChroot(sysRoot))
+	if err != nil {
+		return err
+	}
+
+	for _, conf := range hpp.Spec.Pages {
+		var err error
+
+		if conf.Node != nil {
+			logger.V(2).Info("provisioning pages", "numaNode", *conf.Node, "count", conf.Count, "size", conf.Size)
+			err = provisionOnNode(logger, int(*conf.Node), int(conf.Count), conf.Size, sysRoot)
+		} else if len(sysinfo.Nodes) == 1 {
+			logger.V(2).Info("provisioning pages", "numaNode", 0, "count", conf.Count, "size", conf.Size)
+			err = provisionOnNode(logger, 0, int(conf.Count), conf.Size, sysRoot)
+		} else {
+			logger.V(2).Info("splitting pages", "count", conf.Count, "NUMACount", len(sysinfo.Nodes))
+			err = provisionOnMultiNode(logger, len(sysinfo.Nodes), int(conf.Count), conf.Size, sysRoot)
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func provisionOnMultiNode(logger logr.Logger, numaNodeCount, hpCount int, hpSize apiv0.HugePageSize, sysRoot string) error {
+	extra := hpCount % numaNodeCount
+	perNode := hpCount / numaNodeCount
+
+	// we choose to move excess pages on numa node 0 because this is the most common observed practice
+	err := provisionOnNode(logger, 0, perNode+extra, hpSize, sysRoot)
+	if err != nil {
+		return err
+	}
+	for numaNode := 1; numaNode < numaNodeCount; numaNode++ {
+		err = provisionOnNode(logger, numaNode, perNode, hpSize, sysRoot)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func provisionOnNode(logger logr.Logger, numaNode, hpCount int, apiHpSize apiv0.HugePageSize, sysRoot string) error {
+	// this is done too late, we should have proper validation and API translation but good enough for starters.
+	hpSize, err := apiv0.ValidateHugePageSize(apiHpSize)
+	if err != nil {
+		return err
+	}
+	hpPath := filepath.Join(sysRoot, "sys", "devices", "system", "node", fmt.Sprintf("node%d", numaNode), "hugepages", "hugepages-"+string(hpSize), "nr_hugepages")
+	logger.V(4).Info("writing on sysfs", "path", hpPath)
+	dst, err := os.OpenFile(hpPath, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+	_, err = dst.WriteString(strconv.Itoa(hpCount))
+	return fmt.Errorf("failed to write on %q: %w", hpPath, err)
+}
+
+func readConfigurationFrom(r io.Reader) (apiv0.HugePageProvision, error) {
+	hpp := apiv0.HugePageProvision{}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return hpp, err
+	}
+	err = yaml.Unmarshal(data, &hpp)
+	return hpp, err
+}


### PR DESCRIPTION
add optional flow to support the provisioning of hugepages. Initially, we only support dynamic provisioning at runtime, which is the discouraged approach but is much simpler to implement as it doesn't require a node reboot.

Later we will add support to generate the kernel commandline to provision hugepages at node start, reusing the API and the infrastructure added here.

Provisioning support makes sense to complete the functionality, so this driver becomes capable to enumarate, allocate and provision hugepages.

Online on-demand provisioning is intentionally not (yet?) supported: all hugepages need to be provisioned before use, this feature just makes it easier to do, reducing or avoiding the need to use external tools/scripts.