### PR TITLE
attributes: move towards standard naming

### DIFF
--- a/hack/ci/install.tmpl.yaml
+++ b/hack/ci/install.tmpl.yaml
@@ -160,9 +160,9 @@ metadata:
   name: dra.memory
 spec:
   selectors:
-    - cel:
-        expression: device.driver == "dra.memory" && device.attributes["dra.memory"].pageSize
-          == "4k" && device.attributes["dra.memory"].hugeTLB == false
+  - cel:
+      expression: device.driver == "dra.memory" && device.attributes["resource.kubernetes.io"].pageSize
+        == "4k" && device.attributes["resource.kubernetes.io"].hugeTLB == false
 ---
 apiVersion: resource.k8s.io/v1
 kind: DeviceClass
@@ -170,9 +170,9 @@ metadata:
   name: dra.hugepages-2m
 spec:
   selectors:
-    - cel:
-        expression: device.driver == "dra.memory" && device.attributes["dra.memory"].pageSize
-          == "2m" && device.attributes["dra.memory"].hugeTLB == true
+  - cel:
+      expression: device.driver == "dra.memory" && device.attributes["resource.kubernetes.io"].pageSize
+        == "2m" && device.attributes["resource.kubernetes.io"].hugeTLB == true
 ---
 apiVersion: resource.k8s.io/v1
 kind: DeviceClass
@@ -180,6 +180,6 @@ metadata:
   name: dra.hugepages-1g
 spec:
   selectors:
-    - cel:
-        expression: device.driver == "dra.memory" && device.attributes["dra.memory"].pageSize
-          == "1g" && device.attributes["dra.memory"].hugeTLB == true
+  - cel:
+      expression: device.driver == "dra.memory" && device.attributes["resource.kubernetes.io"].pageSize
+        == "1g" && device.attributes["resource.kubernetes.io"].hugeTLB == true

--- a/internal/command/manifests.go
+++ b/internal/command/manifests.go
@@ -85,5 +85,5 @@ func deviceClass(driverName string, ri types.ResourceIdent) resourceapi.DeviceCl
 }
 
 func celExpr(driverName string, ri types.ResourceIdent) string {
-	return fmt.Sprintf("device.driver == %q && device.attributes[\"dra.memory\"].pageSize == %q && device.attributes[\"dra.memory\"].hugeTLB == %v", driverName, ri.PagesizeString(), ri.NeedsHugeTLB())
+	return fmt.Sprintf("device.driver == %q && device.attributes[\"resource.kubernetes.io\"].pageSize == %q && device.attributes[\"resource.kubernetes.io\"].hugeTLB == %v", driverName, ri.PagesizeString(), ri.NeedsHugeTLB())
 }

--- a/pkg/sysinfo/discover_test.go
+++ b/pkg/sysinfo/discover_test.go
@@ -177,15 +177,10 @@ type attrInfo struct {
 func makeAttributes(info attrInfo) map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
 	pNode := ptr.To(info.numaNode)
 	return map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-		// alignment compatibility: dra-driver-sriov
 		"resource.kubernetes.io/numaNode": {IntValue: pNode},
-		// alignment compatibility: dra-driver-cpu
-		"dra.cpu/numaNode": {IntValue: pNode},
-		// alignment compatibility: dranet
-		"dra.net/numaNode": {IntValue: pNode},
-		// our own attributes, at last
-		"dra.memory/numaNode": {IntValue: pNode},
-		"dra.memory/pageSize": {StringValue: ptr.To(info.sizeName)},
-		"dra.memory/hugeTLB":  {BoolValue: ptr.To(info.hugeTLB)},
+		"resource.kubernetes.io/pageSize": {StringValue: ptr.To(info.sizeName)},
+		"resource.kubernetes.io/hugeTLB":  {BoolValue: ptr.To(info.hugeTLB)},
+		"dra.cpu/numaNode":                {IntValue: pNode},
+		"dra.net/numaNode":                {IntValue: pNode},
 	}
 }

--- a/pkg/sysinfo/rslice_test.go
+++ b/pkg/sysinfo/rslice_test.go
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sysinfo
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/ffromani/dra-driver-memory/pkg/types"
+)
+
+func TestMakeAttributes(t *testing.T) {
+	type testcase struct {
+		span     types.Span
+		expected map[resourceapi.QualifiedName]resourceapi.DeviceAttribute
+	}
+
+	// TODO: at the moment, we explicitly inline all the test permutations we care
+	// about because these are few and manageable; if we add more simple variations,
+	// we should factor out these and create helper functions.
+	testcases := []testcase{
+		{
+			span: types.Span{
+				ResourceIdent: types.ResourceIdent{
+					Kind:     types.Hugepages,
+					Pagesize: uint64(2 * 1 << 20),
+				},
+				Amount:   1, // not really relevant
+				NUMAZone: 0, // we want to be explicit here and not depend on zero-value init of golang
+			},
+			expected: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				StandardDeviceAttributePrefix + "numaNode": {IntValue: ptr.To(int64(0))},
+				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("2m")},
+				StandardDeviceAttributePrefix + "hugeTLB":  {BoolValue: ptr.To(true)},
+				"dra.cpu/numaNode":                         {IntValue: ptr.To(int64(0))},
+				"dra.net/numaNode":                         {IntValue: ptr.To(int64(0))},
+			},
+		},
+		{
+			span: types.Span{
+				ResourceIdent: types.ResourceIdent{
+					Kind:     types.Hugepages,
+					Pagesize: uint64(2 * 1 << 20),
+				},
+				Amount:   1, // not really relevant
+				NUMAZone: 3, // random non-zero value; 1 would have been fine as well
+			},
+			expected: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				StandardDeviceAttributePrefix + "numaNode": {IntValue: ptr.To(int64(3))},
+				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("2m")},
+				StandardDeviceAttributePrefix + "hugeTLB":  {BoolValue: ptr.To(true)},
+				"dra.cpu/numaNode":                         {IntValue: ptr.To(int64(3))},
+				"dra.net/numaNode":                         {IntValue: ptr.To(int64(3))},
+			},
+		},
+		{
+			span: types.Span{
+				ResourceIdent: types.ResourceIdent{
+					Kind:     types.Hugepages,
+					Pagesize: uint64(1 << 30),
+				},
+				Amount:   3, // not really relevant
+				NUMAZone: 0, // we want to be explicit here and not depend on zero-value init of golang
+			},
+			expected: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				StandardDeviceAttributePrefix + "numaNode": {IntValue: ptr.To(int64(0))},
+				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("1g")},
+				StandardDeviceAttributePrefix + "hugeTLB":  {BoolValue: ptr.To(true)},
+				"dra.cpu/numaNode":                         {IntValue: ptr.To(int64(0))},
+				"dra.net/numaNode":                         {IntValue: ptr.To(int64(0))},
+			},
+		},
+		{
+			span: types.Span{
+				ResourceIdent: types.ResourceIdent{
+					Kind:     types.Hugepages,
+					Pagesize: uint64(1 << 30),
+				},
+				Amount:   5, // not really relevant
+				NUMAZone: 3, // random non-zero value; 1 would have been fine as well
+			},
+			expected: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				StandardDeviceAttributePrefix + "numaNode": {IntValue: ptr.To(int64(3))},
+				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("1g")},
+				StandardDeviceAttributePrefix + "hugeTLB":  {BoolValue: ptr.To(true)},
+				"dra.cpu/numaNode":                         {IntValue: ptr.To(int64(3))},
+				"dra.net/numaNode":                         {IntValue: ptr.To(int64(3))},
+			},
+		},
+		{
+			span: types.Span{
+				ResourceIdent: types.ResourceIdent{
+					Kind:     types.Memory,
+					Pagesize: uint64(4 * 1 << 10),
+				},
+				Amount:   2048, // not really relevant
+				NUMAZone: 0,    // we want to be explicit here and not depend on zero-value init of golang
+			},
+			expected: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				StandardDeviceAttributePrefix + "numaNode": {IntValue: ptr.To(int64(0))},
+				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("4k")},
+				StandardDeviceAttributePrefix + "hugeTLB":  {BoolValue: ptr.To(false)},
+				"dra.cpu/numaNode":                         {IntValue: ptr.To(int64(0))},
+				"dra.net/numaNode":                         {IntValue: ptr.To(int64(0))},
+			},
+		},
+		{
+			span: types.Span{
+				ResourceIdent: types.ResourceIdent{
+					Kind:     types.Memory,
+					Pagesize: uint64(4 * 1 << 10),
+				},
+				Amount:   8192, // not really relevant
+				NUMAZone: 2,    // random non-zero value; 1 would have been fine as well
+			},
+			expected: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				StandardDeviceAttributePrefix + "numaNode": {IntValue: ptr.To(int64(2))},
+				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("4k")},
+				StandardDeviceAttributePrefix + "hugeTLB":  {BoolValue: ptr.To(false)},
+				"dra.cpu/numaNode":                         {IntValue: ptr.To(int64(2))},
+				"dra.net/numaNode":                         {IntValue: ptr.To(int64(2))},
+			},
+		},
+	}
+
+	for _, tcase := range testcases {
+		t.Run(tcase.span.String(), func(t *testing.T) {
+			got := MakeAttributes(tcase.span)
+			if diff := cmp.Diff(tcase.expected, got); diff != "" {
+				t.Fatalf("unexpected diff: %v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Trying to keep the names proliferation in check, we now move closer towards what seems to become the standard: deviceattribute package prefixes. We also classify our attributes in maturity classes, still trying to simplify our attribute set.

The attribute naming is not final yet even though we are slowly converging; a final decision needs to be made before we cut the first release, even though
that release will almost surely be an alpha.