### PR TITLE
feat: add summary inspect mode

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -42,7 +42,7 @@ jobs:
     - name: Provision 2M hugepages
       run: sudo ./bin/dramemory -hugepages-provision ./hack/ci/hugepages-2M.yaml
     - name: Hugepages provision feedback check
-      run: ./bin/dramemory -inspect
+      run: ./bin/dramemory -inspect summary
     - name: Kind version check
       run: kind version
     - name: Create and setup K8S kind cluster

--- a/cmd/dramemory/main.go
+++ b/cmd/dramemory/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -45,7 +46,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	if params.DoInspection {
+	if params.DoVersion {
+		ver, ok := command.GetVersion()
+		if !ok {
+			logger.Info("cannot get version")
+			os.Exit(1)
+		}
+		fmt.Println(ver.Build + " " + ver.Golang)
+		os.Exit(0)
+	}
+
+	if params.InspectMode != command.InspectNone {
 		if err := command.Inspect(params, logger); err != nil {
 			logger.Error(err, "inspection failed")
 			os.Exit(1)

--- a/hack/drameminfo
+++ b/hack/drameminfo
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /bin/dramemory -inspect
+exec /bin/dramemory -inspect raw

--- a/internal/command/inspect.go
+++ b/internal/command/inspect.go
@@ -18,18 +18,66 @@ package command
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
+	ghwmemory "github.com/jaypipes/ghw/pkg/memory"
 
 	"sigs.k8s.io/yaml"
 
 	"github.com/ffromani/dra-driver-memory/pkg/sysinfo"
+	"github.com/ffromani/dra-driver-memory/pkg/unitconv"
 )
+
+type InspectMode int
+
+const (
+	InspectNone InspectMode = iota
+	InspectRaw
+	InspectSummary
+)
+
+type InspectValue struct {
+	Mode *InspectMode
+}
+
+func (v InspectValue) String() string {
+	if v.Mode == nil {
+		return ""
+	}
+	switch *v.Mode {
+	case InspectRaw:
+		return "raw"
+	case InspectSummary:
+		return "summary"
+	default:
+		return "none"
+	}
+}
+
+func (v InspectValue) Set(s string) error {
+	s = strings.ToLower(s)
+	switch s {
+	case "raw":
+		*v.Mode = InspectRaw
+	case "summary":
+		*v.Mode = InspectSummary
+	case "none":
+		*v.Mode = InspectNone
+	default:
+		return fmt.Errorf("unsupported mode: %q", s)
+	}
+	return nil
+}
 
 func Inspect(params Params, logger logr.Logger) error {
 	machine, err := sysinfo.GetMachineData(logger, params.SysRoot)
 	if err != nil {
 		return err
+	}
+	if params.InspectMode == InspectSummary {
+		logYAML(logger, convertMachineData(machine))
+		return nil
 	}
 	logYAML(logger, machine)
 	return nil
@@ -41,4 +89,63 @@ func logYAML(logger logr.Logger, obj any) {
 		logger.Error(err, "marshaling data")
 	}
 	fmt.Print(string(data))
+}
+
+type machineData struct {
+	Pagesize      string        `json:"page_size"`
+	Hugepagesizes []string      `json:"huge_page_sizes"`
+	Zones         []machineZone `json:"zones"`
+}
+
+type machineZone struct {
+	ID        int           `json:"id"`
+	Distances []int         `json:"distances"`
+	Memory    machineMemory `json:"memory"`
+}
+
+type machineMemory struct {
+	TotalPhysicalSize     string                     `json:"total_physical_size"`
+	TotalUsableSize       string                     `json:"total_usable_size"`
+	SupportedPageSizes    []string                   `json:"supported_page_sizes"`
+	DefaultHugePageSize   string                     `json:"default_huge_page_size"`
+	TotalHugePageSize     string                     `json:"total_huge_page_size"`
+	HugePageAmountsBySize map[string]HugePageAmounts `json:"huge_page_amounts_by_size"`
+}
+
+type HugePageAmounts = ghwmemory.HugePageAmounts
+
+func convertMachineData(md sysinfo.MachineData) machineData {
+	ret := machineData{
+		Pagesize:      unitconv.SizeInBytesToMinimizedString(md.Pagesize),
+		Hugepagesizes: make([]string, 0, len(md.Hugepagesizes)),
+		Zones:         make([]machineZone, 0, len(md.Zones)),
+	}
+	for _, hpSize := range md.Hugepagesizes {
+		ret.Hugepagesizes = append(ret.Hugepagesizes, unitconv.SizeInBytesToMinimizedString(hpSize))
+	}
+	for _, zone := range md.Zones {
+		zn := machineZone{
+			ID:        zone.ID,
+			Distances: append([]int{}, zone.Distances...),
+		}
+		if zone.Memory != nil {
+			mem := machineMemory{
+				TotalPhysicalSize:     unitconv.SizeInBytesToMinimizedString(uint64(zone.Memory.TotalPhysicalBytes)),
+				TotalUsableSize:       unitconv.SizeInBytesToMinimizedString(uint64(zone.Memory.TotalUsableBytes)),
+				SupportedPageSizes:    make([]string, 0, len(zone.Memory.SupportedPageSizes)),
+				DefaultHugePageSize:   unitconv.SizeInBytesToMinimizedString(zone.Memory.DefaultHugePageSize),
+				TotalHugePageSize:     unitconv.SizeInBytesToMinimizedString(uint64(zone.Memory.TotalHugePageBytes)),
+				HugePageAmountsBySize: make(map[string]HugePageAmounts, len(zone.Memory.HugePageAmountsBySize)),
+			}
+			for _, supSize := range zone.Memory.SupportedPageSizes {
+				mem.SupportedPageSizes = append(mem.SupportedPageSizes, unitconv.SizeInBytesToMinimizedString(supSize))
+			}
+			for hpSize, hpAmounts := range zone.Memory.HugePageAmountsBySize {
+				mem.HugePageAmountsBySize[unitconv.SizeInBytesToMinimizedString(hpSize)] = *hpAmounts
+			}
+			zn.Memory = mem
+		}
+		ret.Zones = append(ret.Zones, zn)
+	}
+	return ret
 }


### PR DESCRIPTION
This inspect mode prints data in human-friendly way. We will still support the old inspection mode
by retroactively renaming it `raw`.