### PR TITLE
units: use same unit as k8s as much as possible

### DIFF
--- a/hack/ci/install.tmpl.yaml
+++ b/hack/ci/install.tmpl.yaml
@@ -169,7 +169,7 @@ spec:
   selectors:
   - cel:
       expression: device.driver == "dra.memory" && device.attributes["resource.kubernetes.io"].pageSize
-        == "4k" && device.attributes["resource.kubernetes.io"].hugeTLB == false
+        == "4Ki" && device.attributes["resource.kubernetes.io"].hugeTLB == false
 ---
 apiVersion: resource.k8s.io/v1
 kind: DeviceClass
@@ -179,7 +179,7 @@ spec:
   selectors:
   - cel:
       expression: device.driver == "dra.memory" && device.attributes["resource.kubernetes.io"].pageSize
-        == "2m" && device.attributes["resource.kubernetes.io"].hugeTLB == true
+        == "2Mi" && device.attributes["resource.kubernetes.io"].hugeTLB == true
 ---
 apiVersion: resource.k8s.io/v1
 kind: DeviceClass
@@ -189,4 +189,4 @@ spec:
   selectors:
   - cel:
       expression: device.driver == "dra.memory" && device.attributes["resource.kubernetes.io"].pageSize
-        == "1g" && device.attributes["resource.kubernetes.io"].hugeTLB == true
+        == "1Gi" && device.attributes["resource.kubernetes.io"].hugeTLB == true

--- a/hack/ci/install_unpriv.tmpl.yaml
+++ b/hack/ci/install_unpriv.tmpl.yaml
@@ -162,7 +162,7 @@ spec:
   selectors:
   - cel:
       expression: device.driver == "dra.memory" && device.attributes["resource.kubernetes.io"].pageSize
-        == "4k" && device.attributes["resource.kubernetes.io"].hugeTLB == false
+        == "4Ki" && device.attributes["resource.kubernetes.io"].hugeTLB == false
 ---
 apiVersion: resource.k8s.io/v1
 kind: DeviceClass
@@ -172,7 +172,7 @@ spec:
   selectors:
   - cel:
       expression: device.driver == "dra.memory" && device.attributes["resource.kubernetes.io"].pageSize
-        == "2m" && device.attributes["resource.kubernetes.io"].hugeTLB == true
+        == "2Mi" && device.attributes["resource.kubernetes.io"].hugeTLB == true
 ---
 apiVersion: resource.k8s.io/v1
 kind: DeviceClass
@@ -182,4 +182,4 @@ spec:
   selectors:
   - cel:
       expression: device.driver == "dra.memory" && device.attributes["resource.kubernetes.io"].pageSize
-        == "1g" && device.attributes["resource.kubernetes.io"].hugeTLB == true
+        == "1Gi" && device.attributes["resource.kubernetes.io"].hugeTLB == true

--- a/pkg/sysinfo/rslice.go
+++ b/pkg/sysinfo/rslice.go
@@ -17,6 +17,8 @@
 package sysinfo
 
 import (
+	"strings"
+
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8srand "k8s.io/apimachinery/pkg/util/rand"
@@ -85,5 +87,5 @@ func ToDevice(sp types.Span) resourceapi.Device {
 // Since users are expected to select memory devices by attribute and not by name, we just use a
 // random suffix for the time being and move on.
 var MakeDeviceName = func(devName string) string {
-	return devName + "-" + k8srand.String(6)
+	return strings.ToLower(devName) + "-" + k8srand.String(6)
 }

--- a/pkg/sysinfo/rslice_test.go
+++ b/pkg/sysinfo/rslice_test.go
@@ -48,7 +48,7 @@ func TestMakeAttributes(t *testing.T) {
 			},
 			expected: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 				StandardDeviceAttributePrefix + "numaNode": {IntValue: ptr.To(int64(0))},
-				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("2m")},
+				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("2Mi")},
 				StandardDeviceAttributePrefix + "hugeTLB":  {BoolValue: ptr.To(true)},
 				"dra.cpu/numaNode":                         {IntValue: ptr.To(int64(0))},
 				"dra.net/numaNode":                         {IntValue: ptr.To(int64(0))},
@@ -65,7 +65,7 @@ func TestMakeAttributes(t *testing.T) {
 			},
 			expected: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 				StandardDeviceAttributePrefix + "numaNode": {IntValue: ptr.To(int64(3))},
-				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("2m")},
+				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("2Mi")},
 				StandardDeviceAttributePrefix + "hugeTLB":  {BoolValue: ptr.To(true)},
 				"dra.cpu/numaNode":                         {IntValue: ptr.To(int64(3))},
 				"dra.net/numaNode":                         {IntValue: ptr.To(int64(3))},
@@ -82,7 +82,7 @@ func TestMakeAttributes(t *testing.T) {
 			},
 			expected: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 				StandardDeviceAttributePrefix + "numaNode": {IntValue: ptr.To(int64(0))},
-				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("1g")},
+				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("1Gi")},
 				StandardDeviceAttributePrefix + "hugeTLB":  {BoolValue: ptr.To(true)},
 				"dra.cpu/numaNode":                         {IntValue: ptr.To(int64(0))},
 				"dra.net/numaNode":                         {IntValue: ptr.To(int64(0))},
@@ -99,7 +99,7 @@ func TestMakeAttributes(t *testing.T) {
 			},
 			expected: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 				StandardDeviceAttributePrefix + "numaNode": {IntValue: ptr.To(int64(3))},
-				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("1g")},
+				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("1Gi")},
 				StandardDeviceAttributePrefix + "hugeTLB":  {BoolValue: ptr.To(true)},
 				"dra.cpu/numaNode":                         {IntValue: ptr.To(int64(3))},
 				"dra.net/numaNode":                         {IntValue: ptr.To(int64(3))},
@@ -116,7 +116,7 @@ func TestMakeAttributes(t *testing.T) {
 			},
 			expected: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 				StandardDeviceAttributePrefix + "numaNode": {IntValue: ptr.To(int64(0))},
-				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("4k")},
+				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("4Ki")},
 				StandardDeviceAttributePrefix + "hugeTLB":  {BoolValue: ptr.To(false)},
 				"dra.cpu/numaNode":                         {IntValue: ptr.To(int64(0))},
 				"dra.net/numaNode":                         {IntValue: ptr.To(int64(0))},
@@ -133,7 +133,7 @@ func TestMakeAttributes(t *testing.T) {
 			},
 			expected: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 				StandardDeviceAttributePrefix + "numaNode": {IntValue: ptr.To(int64(2))},
-				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("4k")},
+				StandardDeviceAttributePrefix + "pageSize": {StringValue: ptr.To("4Ki")},
 				StandardDeviceAttributePrefix + "hugeTLB":  {BoolValue: ptr.To(false)},
 				"dra.cpu/numaNode":                         {IntValue: ptr.To(int64(2))},
 				"dra.net/numaNode":                         {IntValue: ptr.To(int64(2))},

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -38,7 +38,7 @@ type ResourceIdent struct {
 	Pagesize uint64 //bytes
 }
 
-// name is in the form `memory-4k` or `hugepages-1g`
+// name is in the form `memory-4Ki` or `hugepages-1Gi`
 func ResourceIdentFromName(name string) (ResourceIdent, error) {
 	parts := strings.SplitN(name, "-", 2)
 	if len(parts) != 2 {

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -33,7 +33,7 @@ func TestResourceIdentNameRoundTrip(t *testing.T) {
 
 	testcases := []testcase{
 		{
-			fullName: "memory-4k",
+			fullName: "memory-4Ki",
 			name:     "memory",
 			ident: ResourceIdent{
 				Kind:     Memory,
@@ -41,8 +41,8 @@ func TestResourceIdentNameRoundTrip(t *testing.T) {
 			},
 		},
 		{
-			fullName: "hugepages-2m",
-			name:     "hugepages-2m",
+			fullName: "hugepages-2Mi",
+			name:     "hugepages-2Mi",
 			hugeTLB:  true,
 			ident: ResourceIdent{
 				Kind:     Hugepages,
@@ -50,8 +50,8 @@ func TestResourceIdentNameRoundTrip(t *testing.T) {
 			},
 		},
 		{
-			fullName: "hugepages-1g",
-			name:     "hugepages-1g",
+			fullName: "hugepages-1Gi",
+			name:     "hugepages-1Gi",
 			hugeTLB:  true,
 			ident: ResourceIdent{
 				Kind:     Hugepages,
@@ -80,21 +80,21 @@ func TestResourceIdentCapacityName(t *testing.T) {
 
 	testcases := []testcase{
 		{
-			fullName: "memory-4k",
+			fullName: "memory-4Ki",
 			ident: ResourceIdent{
 				Kind:     Memory,
 				Pagesize: 4 * 1024,
 			},
 		},
 		{
-			fullName: "hugepages-2m",
+			fullName: "hugepages-2Mi",
 			ident: ResourceIdent{
 				Kind:     Hugepages,
 				Pagesize: 2 * 1024 * 1024,
 			},
 		},
 		{
-			fullName: "hugepages-1g",
+			fullName: "hugepages-1Gi",
 			ident: ResourceIdent{
 				Kind:     Hugepages,
 				Pagesize: 1024 * 1024 * 1024,
@@ -118,21 +118,21 @@ func TestResourceIdentMinimumAllocatable(t *testing.T) {
 
 	testcases := []testcase{
 		{
-			fullName: "memory-4k",
+			fullName: "memory-4Ki",
 			ident: ResourceIdent{
 				Kind:     Memory,
 				Pagesize: 4 * 1024,
 			},
 		},
 		{
-			fullName: "hugepages-2m",
+			fullName: "hugepages-2Mi",
 			ident: ResourceIdent{
 				Kind:     Hugepages,
 				Pagesize: 2 * 1024 * 1024,
 			},
 		},
 		{
-			fullName: "hugepages-1g",
+			fullName: "hugepages-1Gi",
 			ident: ResourceIdent{
 				Kind:     Hugepages,
 				Pagesize: 1024 * 1024 * 1024,

--- a/pkg/unitconv/unit_test.go
+++ b/pkg/unitconv/unit_test.go
@@ -33,23 +33,23 @@ func TestSizeToStringRoundTrip(t *testing.T) {
 	testcases := []testcase{
 		// good cases, add them at the bottom of the section
 		{
-			sval: "7b",
+			sval: "7B",
 			uval: 7,
 		},
 		{
-			sval: "4k",
+			sval: "4Ki",
 			uval: 4 * 1024,
 		},
 		{
-			sval: "64k",
+			sval: "64Ki",
 			uval: 64 * 1024,
 		},
 		{
-			sval: "2m",
+			sval: "2Mi",
 			uval: 2 * 1024 * 1024,
 		},
 		{
-			sval: "1g",
+			sval: "1Gi",
 			uval: 1024 * 1024 * 1024,
 		},
 		// bad cases, add them at the bottom of the section
@@ -75,6 +75,10 @@ func TestSizeToStringRoundTrip(t *testing.T) {
 		},
 		{
 			sval: "1pb",
+			fail: true,
+		},
+		{
+			sval: "1gi",
 			fail: true,
 		},
 	}
@@ -181,19 +185,19 @@ func TestMinimize(t *testing.T) {
 		},
 		{
 			input:    "B",
-			expected: "b",
+			expected: "B",
 		},
 		{
 			input:    "KiB",
-			expected: "k",
+			expected: "Ki",
 		},
 		{
 			input:    "MiB",
-			expected: "m",
+			expected: "Mi",
 		},
 		{
 			input:    "GiB",
-			expected: "g",
+			expected: "Gi",
 		},
 	}
 

--- a/test/e2e/hugepages_test.go
+++ b/test/e2e/hugepages_test.go
@@ -132,7 +132,7 @@ var _ = ginkgo.Describe("Hugepages Allocation", ginkgo.Serial, ginkgo.Ordered, g
 							Name:    "container-with-hugepages-2m",
 							Image:   dramemoryTesterImage,
 							Command: []string{"/bin/dramemtester"},
-							Args:    []string{"-use-hugetlb=true", "-alloc-size=32m", "-numa-align=single", "-run-forever"},
+							Args:    []string{"-use-hugetlb=true", "-alloc-size=32Mi", "-numa-align=single", "-run-forever"},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
@@ -212,7 +212,7 @@ var _ = ginkgo.Describe("Hugepages Allocation", ginkgo.Serial, ginkgo.Ordered, g
 							Name:    "container-over-hugepages-2m",
 							Image:   dramemoryTesterImage,
 							Command: []string{"/bin/dramemtester"},
-							Args:    []string{"-use-hugetlb=true", "-alloc-size=48m", "-should-fail"},
+							Args:    []string{"-use-hugetlb=true", "-alloc-size=48Mi", "-should-fail"},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
@@ -312,7 +312,7 @@ var _ = ginkgo.Describe("Hugepages Allocation", ginkgo.Serial, ginkgo.Ordered, g
 							Name:    "container-with-hugepages-1g",
 							Image:   dramemoryTesterImage,
 							Command: []string{"/bin/dramemtester"},
-							Args:    []string{"-use-hugetlb=true", "-alloc-size=1g", "-numa-align=single", "-run-forever"},
+							Args:    []string{"-use-hugetlb=true", "-alloc-size=1Gi", "-numa-align=single", "-run-forever"},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
@@ -392,7 +392,7 @@ var _ = ginkgo.Describe("Hugepages Allocation", ginkgo.Serial, ginkgo.Ordered, g
 							Name:    "container-over-hugepages-1g",
 							Image:   dramemoryTesterImage,
 							Command: []string{"/bin/dramemtester"},
-							Args:    []string{"-use-hugetlb=true", "-alloc-size=2g", "-should-fail"},
+							Args:    []string{"-use-hugetlb=true", "-alloc-size=2Gi", "-should-fail"},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),

--- a/test/e2e/memory_test.go
+++ b/test/e2e/memory_test.go
@@ -123,7 +123,7 @@ var _ = ginkgo.Describe("Memory Allocation", ginkgo.Serial, ginkgo.Ordered, gink
 							Name:    "container-with-memory",
 							Image:   dramemoryTesterImage,
 							Command: []string{"/bin/dramemtester"},
-							Args:    []string{"-use-hugetlb=false", "-alloc-size=480m", "-numa-align=single", "-run-forever"}, // keep a safe margin
+							Args:    []string{"-use-hugetlb=false", "-alloc-size=480Mi", "-numa-align=single", "-run-forever"}, // keep a safe margin
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
@@ -203,7 +203,7 @@ var _ = ginkgo.Describe("Memory Allocation", ginkgo.Serial, ginkgo.Ordered, gink
 							Name:    "container-over-memory",
 							Image:   dramemoryTesterImage,
 							Command: []string{"/bin/dramemtester"},
-							Args:    []string{"-use-hugetlb=false", "-alloc-size=520m", "-should-fail"},
+							Args:    []string{"-use-hugetlb=false", "-alloc-size=520Mi", "-should-fail"},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),


### PR DESCRIPTION
Unless there's a clear reason to, which must be documented, we should use same units and semantics as kube's, in order to streamline UX and minimize the user friction.

Fixes: https://github.com/ffromani/dra-driver-memory/issues/31