### PR TITLE
manifests: set selector and priority

### DIFF
--- a/hack/ci/install.tmpl.yaml
+++ b/hack/ci/install.tmpl.yaml
@@ -96,6 +96,9 @@ spec:
         k8s-app: dramemory
         build: devel
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
       hostNetwork: true
       tolerations:
         - operator: Exists

--- a/hack/ci/install_unpriv.tmpl.yaml
+++ b/hack/ci/install_unpriv.tmpl.yaml
@@ -96,6 +96,9 @@ spec:
         k8s-app: dramemory
         build: devel
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
       hostNetwork: true
       tolerations:
         - operator: Exists


### PR DESCRIPTION
we support only linux, let's be explicit about it
the plugin is node-critical, let's mark it as such prioritywise.