### PR TITLE
ci: relase: fix repo name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
-          registry: quay.io/ffromani
+          registry: quay.io/fromani
           username: ${{ secrets.QUAY_IO_USERNAME }}
           password: ${{ secrets.QUAY_IO_ROBOTOKEN }}
 


### PR DESCRIPTION
fix typo (github username vs quay.io username confusion)