### PR TITLE
attributes: don't abuse the resource.kubernetes.io namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Each memory device exposes the following attributes:
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
-| `resource.kubernetes.io/numaNode` | int | NUMA node where the memory resides |
-| `resource.kubernetes.io/pageSize` | string | Page size (e.g., `4k`, `2m`, `1g`) |
-| `resource.kubernetes.io/hugeTLB` | bool | Whether this is a hugepage resource |
+| `dra.memory/numaNode` | int | NUMA node where the memory resides |
+| `dra.memory/pageSize` | string | Page size (e.g., `4k`, `2m`, `1g`) |
+| `dra.memory/hugeTLB` | bool | Whether this is a hugepage resource |
 
 Compatibility attributes for other DRA drivers are also exposed:
 - `dra.cpu/numaNodeID` - for dra-driver-cpu

--- a/hack/ci/install.tmpl.yaml
+++ b/hack/ci/install.tmpl.yaml
@@ -171,8 +171,8 @@ metadata:
 spec:
   selectors:
   - cel:
-      expression: device.driver == "dra.memory" && device.attributes["resource.kubernetes.io"].pageSize
-        == "4Ki" && device.attributes["resource.kubernetes.io"].hugeTLB == false
+      expression: device.driver == "dra.memory" && device.attributes["dra.memory"].pageSize
+        == "4Ki" && device.attributes["dra.memory"].hugeTLB == false
 ---
 apiVersion: resource.k8s.io/v1
 kind: DeviceClass
@@ -181,8 +181,8 @@ metadata:
 spec:
   selectors:
   - cel:
-      expression: device.driver == "dra.memory" && device.attributes["resource.kubernetes.io"].pageSize
-        == "2Mi" && device.attributes["resource.kubernetes.io"].hugeTLB == true
+      expression: device.driver == "dra.memory" && device.attributes["dra.memory"].pageSize
+        == "2Mi" && device.attributes["dra.memory"].hugeTLB == true
 ---
 apiVersion: resource.k8s.io/v1
 kind: DeviceClass
@@ -191,5 +191,5 @@ metadata:
 spec:
   selectors:
   - cel:
-      expression: device.driver == "dra.memory" && device.attributes["resource.kubernetes.io"].pageSize
-        == "1Gi" && device.attributes["resource.kubernetes.io"].hugeTLB == true
+      expression: device.driver == "dra.memory" && device.attributes["dra.memory"].pageSize
+        == "1Gi" && device.attributes["dra.memory"].hugeTLB == true

--- a/hack/ci/install_unpriv.tmpl.yaml
+++ b/hack/ci/install_unpriv.tmpl.yaml
@@ -164,8 +164,8 @@ metadata:
 spec:
   selectors:
   - cel:
-      expression: device.driver == "dra.memory" && device.attributes["resource.kubernetes.io"].pageSize
-        == "4Ki" && device.attributes["resource.kubernetes.io"].hugeTLB == false
+      expression: device.driver == "dra.memory" && device.attributes["dra.memory"].pageSize
+        == "4Ki" && device.attributes["dra.memory"].hugeTLB == false
 ---
 apiVersion: resource.k8s.io/v1
 kind: DeviceClass
@@ -174,8 +174,8 @@ metadata:
 spec:
   selectors:
   - cel:
-      expression: device.driver == "dra.memory" && device.attributes["resource.kubernetes.io"].pageSize
-        == "2Mi" && device.attributes["resource.kubernetes.io"].hugeTLB == true
+      expression: device.driver == "dra.memory" && device.attributes["dra.memory"].pageSize
+        == "2Mi" && device.attributes["dra.memory"].hugeTLB == true
 ---
 apiVersion: resource.k8s.io/v1
 kind: DeviceClass
@@ -184,5 +184,5 @@ metadata:
 spec:
   selectors:
   - cel:
-      expression: device.driver == "dra.memory" && device.attributes["resource.kubernetes.io"].pageSize
-        == "1Gi" && device.attributes["resource.kubernetes.io"].hugeTLB == true
+      expression: device.driver == "dra.memory" && device.attributes["dra.memory"].pageSize
+        == "1Gi" && device.attributes["dra.memory"].hugeTLB == true

--- a/pkg/command/manifests.go
+++ b/pkg/command/manifests.go
@@ -85,5 +85,5 @@ func deviceClass(driverName string, ri types.ResourceIdent) resourceapi.DeviceCl
 }
 
 func celExpr(driverName string, ri types.ResourceIdent) string {
-	return fmt.Sprintf("device.driver == %q && device.attributes[\"resource.kubernetes.io\"].pageSize == %q && device.attributes[\"resource.kubernetes.io\"].hugeTLB == %v", driverName, ri.PagesizeString(), ri.NeedsHugeTLB())
+	return fmt.Sprintf("device.driver == %q && device.attributes[\"dra.memory\"].pageSize == %q && device.attributes[\"dra.memory\"].hugeTLB == %v", driverName, ri.PagesizeString(), ri.NeedsHugeTLB())
 }

--- a/pkg/sysinfo/discover_amd64_test.go
+++ b/pkg/sysinfo/discover_amd64_test.go
@@ -370,11 +370,11 @@ type attrInfo struct {
 func makeAttributes(info attrInfo) map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
 	pNode := ptr.To(info.numaNode)
 	return map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-		"resource.kubernetes.io/numaNode": {IntValue: pNode},
-		"resource.kubernetes.io/pageSize": {StringValue: ptr.To(info.sizeName)},
-		"resource.kubernetes.io/hugeTLB":  {BoolValue: ptr.To(info.hugeTLB)},
-		"dra.cpu/numaNodeID":              {IntValue: pNode},
-		"dra.net/numaNode":                {IntValue: pNode},
+		"dra.memory/numaNode": {IntValue: pNode},
+		"dra.memory/pageSize": {StringValue: ptr.To(info.sizeName)},
+		"dra.memory/hugeTLB":  {BoolValue: ptr.To(info.hugeTLB)},
+		"dra.cpu/numaNodeID":  {IntValue: pNode},
+		"dra.net/numaNode":    {IntValue: pNode},
 	}
 }
 

--- a/pkg/sysinfo/rslice.go
+++ b/pkg/sysinfo/rslice.go
@@ -22,14 +22,13 @@ import (
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8srand "k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/dynamic-resource-allocation/deviceattribute"
 	"k8s.io/utils/ptr"
 
 	"github.com/ffromani/dra-driver-memory/pkg/types"
 )
 
 const (
-	StandardDeviceAttributePrefix = deviceattribute.StandardDeviceAttributePrefix
+	StandardDeviceAttributePrefix = "dra.memory/"
 )
 
 func MakeAttributes(sp types.Span) map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {

--- a/test/pkg/fixture/fixture.go
+++ b/test/pkg/fixture/fixture.go
@@ -147,12 +147,12 @@ func findMemoryDeviceInResourceSlice(lh logr.Logger, resourceSlice *resourcev1.R
 
 func matchesByAttributes(lh logr.Logger, attrs map[resourcev1.QualifiedName]resourcev1.DeviceAttribute, size string) bool {
 	lh.Info("inspecting", "attributes", attrs)
-	val, ok := attrs[resourcev1.QualifiedName("resource.kubernetes.io/hugeTLB")]
+	val, ok := attrs[resourcev1.QualifiedName("dra.memory/hugeTLB")]
 	if !ok || val.BoolValue == nil {
 		return false
 	}
 	lh.Info("hugeTLB bool present")
-	val, ok = attrs[resourcev1.QualifiedName("resource.kubernetes.io/pageSize")]
+	val, ok = attrs[resourcev1.QualifiedName("dra.memory/pageSize")]
 	if !ok || val.StringValue == nil || *val.StringValue != size {
 		return false
 	}


### PR DESCRIPTION
DRA drivers should not use the resource.kubernetes.io namespace for non-official attributes. They should use their own namespace.

xref: https://github.com/kubernetes-sigs/dra-driver-cpu/pull/65#discussion_r2838403474