### PR TITLE
rbac: add DRA granular status authorization rules

### DIFF
--- a/hack/ci/install.tmpl.yaml
+++ b/hack/ci/install.tmpl.yaml
@@ -48,6 +48,15 @@ rules:
       - patch
       - update
   - apiGroups:
+      - "resource.k8s.io"
+    resources:
+      - resourceclaims/driver
+    verbs:
+      - associated-node:update
+      - associated-node:patch
+    resourceNames:
+      - dra.memory
+  - apiGroups:
       - ""
     resources:
       - pods

--- a/hack/ci/install_unpriv.tmpl.yaml
+++ b/hack/ci/install_unpriv.tmpl.yaml
@@ -48,6 +48,15 @@ rules:
       - patch
       - update
   - apiGroups:
+      - "resource.k8s.io"
+    resources:
+      - resourceclaims/driver
+    verbs:
+      - associated-node:update
+      - associated-node:patch
+    resourceNames:
+      - dra.memory
+  - apiGroups:
       - ""
     resources:
       - pods


### PR DESCRIPTION
Starting in Kubernetes v1.36, the `DRAResourceClaimGranularStatusAuthorization` feature gate (beta, on-by-default) enforces fine-grained authorization checks for `ResourceClaim` status updates.

Node-local DRA drivers now require additional permissions on the `resourceclaims/driver` synthetic subresource with `associated-node:update` and `associated-node:patch` verbs.

This updates both CI install templates (`install.tmpl.yaml` and `install_unpriv.tmpl.yaml`) to add the required rule scoped to driver name `dra.memory`.

These new permissions are inert on Kubernetes versions prior to v1.36.

Ref: kubernetes/kubernetes#138149